### PR TITLE
Fix Error When Toggling to Terminal That Has Been Deleted

### DIFF
--- a/lua/intervention.lua
+++ b/lua/intervention.lua
@@ -15,7 +15,7 @@ function M.mark()
 end
 
 function M.toggle_term()
-  if M._term_buffer then
+  if M._term_buffer and vim.api.nvim_buf_is_valid(M._term_buffer) then
     if vim.api.nvim_get_current_buf() == M._term_buffer then
       M.recall()
     else
@@ -34,6 +34,10 @@ end
 function M.setup(opts)
   -- NOOP for compat with Lazy.nvim patterns.
   return
+end
+
+function M.version()
+  return "0.1.0"
 end
 
 return M


### PR DESCRIPTION
To verify:

1. Open a split.
2. Toggle to terminal using the toggle_term() function.
3. Run `:lua vim.api.nvim_buf_delete(vim.api.nvim_get_current_buf(), {force=true})` from the terminal buffer.
4. Repeat step 2.

There should be an invalid buffer number error before this patch and the terminal should open after this patch.