### PR TITLE
facepalm(terminal): Add Default Value for toggle_term opts Table

### DIFF
--- a/README.md
+++ b/README.md
@@ -27,11 +27,11 @@ Use as a regular lua module:
 local lsp_zero = require('lsp-zero')
 local intervention = require("intervention")
 
-vim.keymap.set("n", "<leader>q", function() intervention:recall() end)
+vim.keymap.set("n", "<leader>q", function() intervention.recall() end)
 
 lsp_zero.on_attach(function(client, bufnr)
   local opts = {buffer = bufnr, remap = false}
-  vim.keymap.set("n", "<leader>g", function() intervention:mark() vim.lsp.buf.definition() end, opts)
+  vim.keymap.set("n", "<leader>g", function() intervention.mark() vim.lsp.buf.definition() end, opts)
 end)
 ```
 
@@ -48,7 +48,7 @@ its environment:
 ```lua
 local intervention = require("intervention")
 
-vim.keymap.set({"n","t"}, "<leader>t", function() intervention:toggle_term() end)
+vim.keymap.set({"n","t"}, "<leader>t", function() intervention.toggle_term() end)
 ```
 
 This will switch to a dedicated terminal buffer and record the current buffer with `mark()` so that
@@ -61,6 +61,11 @@ in each neovim session.
 This does not mess with any of your other configuration related to terminals or interfere with
 any of the behavior of neovim's terminal commands, so it should be compatible with any other plugins
 you use for terminal navigation.
+
+`toggle_term` accepts an `opts` table defaulting to: `{update_mark=true}`.
+
+If `update_mark` is set to anything other than `true`, then `toggle_term` will call `mark()` before
+opening the terminal. This is useful for potentially ephemeral buffer filetypes like netrw.
 
 ## Why not global marks?
 

--- a/lua/intervention.lua
+++ b/lua/intervention.lua
@@ -14,8 +14,11 @@ function M.mark()
   M._recall_buffer = vim.api.nvim_get_current_buf()
 end
 
--- @param opts A table defauling to: {update_mark = true}
+-- @param opts A table defaulting to: {update_mark = true}
 function M.toggle_term(opts)
+  if opts == nil then
+    opts = {update_mark = true}
+  end
   if M._term_buffer and vim.api.nvim_buf_is_valid(M._term_buffer) then
     if vim.api.nvim_get_current_buf() == M._term_buffer then
       M.recall()


### PR DESCRIPTION
I forgot to set the default for the opts table, so lua was crashing if toggle_term was called without arguments breaking backwards compat with the original version of the function.